### PR TITLE
Remove the use of in-place operations

### DIFF
--- a/smirnoffee/potentials/valence.py
+++ b/smirnoffee/potentials/valence.py
@@ -63,10 +63,10 @@ def evaluate_harmonic_angle_energy(
         return torch.zeros(1)
 
     vector_ab = conformer[atom_indices[:, 1]] - conformer[atom_indices[:, 0]]
-    vector_ab /= torch.norm(vector_ab, dim=1).unsqueeze(1)
+    vector_ab = vector_ab / torch.norm(vector_ab, dim=1).unsqueeze(1)
 
     vector_ac = conformer[atom_indices[:, 1]] - conformer[atom_indices[:, 2]]
-    vector_ac /= torch.norm(vector_ac, dim=1).unsqueeze(1)
+    vector_ac = vector_ac / torch.norm(vector_ac, dim=1).unsqueeze(1)
 
     # TODO: handle the ACOS singularity.
     angles = torch.rad2deg(torch.acos((vector_ab * vector_ac).sum(dim=1)))
@@ -108,14 +108,18 @@ def _evaluate_cosine_torsion_energy(
     vector_ab_cross_cb = torch.cross(vector_ab, vector_cb, dim=1)
     vector_cb_cross_cd = torch.cross(vector_cb, vector_cd, dim=1)
 
-    vector_ab_cross_cb /= torch.norm(vector_ab_cross_cb, dim=1).unsqueeze(1)
-    vector_cb_cross_cd /= torch.norm(vector_cb_cross_cd, dim=1).unsqueeze(1)
+    vector_ab_cross_cb = vector_ab_cross_cb / torch.norm(
+        vector_ab_cross_cb, dim=1
+    ).unsqueeze(1)
+    vector_cb_cross_cd = vector_cb_cross_cd / torch.norm(
+        vector_cb_cross_cd, dim=1
+    ).unsqueeze(1)
 
     cos_phi = (vector_ab_cross_cb * vector_cb_cross_cd).sum(dim=1)
 
     # TODO: handle the ACOS singularity.
     phi = torch.acos(cos_phi)
-    phi *= torch.where((vector_ab * vector_cb_cross_cd).sum(dim=1) < 0, -1.0, 1.0)
+    phi = phi * torch.where((vector_ab * vector_cb_cross_cd).sum(dim=1) < 0, -1.0, 1.0)
 
     return (
         parameters[:, 0]


### PR DESCRIPTION
## Description

This PR removes instances of 'in-place' operations which `pytorch` cannot backpropagate through.

## Status
- [X] Ready to go