### PR TITLE
Add simple examples

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,11 +31,14 @@ jobs:
       - name: Run isort
         run: |
           isort --recursive --check-only smirnoffee
+          isort --recursive --check-only examples
 
       - name: Run black
         run: |
           black smirnoffee --check
+          black examples --check
 
       - name: Run flake8
         run: |
           flake8 smirnoffee
+          flake8 examples

--- a/examples/conformer-minimization.py
+++ b/examples/conformer-minimization.py
@@ -1,0 +1,46 @@
+import torch
+from openff.system.components.system import System
+from openff.toolkit.topology import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from simtk import unit
+from torch import optim
+
+from smirnoffee.potentials.potentials import evaluate_system_energy
+
+
+def main():
+
+    # Load in a paracetamol molecules, generate a conformer for it, and perturb the
+    # conformer to ensure it needs minimization.
+    molecule: Molecule = Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")
+    molecule.generate_conformers(n_conformers=1)
+    molecule.to_file("initial.xyz", "XYZ")
+
+    conformer = torch.tensor(molecule.conformers[0].value_in_unit(unit.angstrom)) * 1.10
+    conformer.requires_grad = True
+
+    # Parameterize the molecule
+    openff_system = System.from_smirnoff(
+        ForceField("openff_unconstrained-1.0.0.offxml"), molecule.to_topology()
+    )
+
+    # Minimize the conformer
+    optimizer = optim.Adam([conformer], lr=0.02)
+
+    for epoch in range(75):
+
+        energy = evaluate_system_energy(openff_system, conformer)
+        energy.backward()
+
+        optimizer.step()
+        optimizer.zero_grad()
+
+        print(f"Epoch {epoch}: E={energy.item()} kJ / mol")
+
+    # Save the final conformer
+    molecule._conformers = [conformer.detach().numpy() * unit.angstrom]
+    molecule.to_file("final.xyz", "XYZ")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conformer-minimization.py
+++ b/examples/conformer-minimization.py
@@ -10,7 +10,7 @@ from smirnoffee.potentials.potentials import evaluate_system_energy
 
 def main():
 
-    # Load in a paracetamol molecules, generate a conformer for it, and perturb the
+    # Load in a paracetamol molecule, generate a conformer for it, and perturb the
     # conformer to ensure it needs minimization.
     molecule: Molecule = Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")
     molecule.generate_conformers(n_conformers=1)

--- a/examples/parameter-gradients.py
+++ b/examples/parameter-gradients.py
@@ -39,7 +39,7 @@ def main():
         openff_system,
         conformer,
         parameter_delta=parameter_delta,
-        parameter_delta_ids=parameter_ids
+        parameter_delta_ids=parameter_ids,
     )
     energy.backward()
 

--- a/examples/parameter-gradients.py
+++ b/examples/parameter-gradients.py
@@ -9,8 +9,7 @@ from smirnoffee.potentials.potentials import evaluate_system_energy
 
 def main():
 
-    # Load in a paracetamol molecules, generate a conformer for it, and perturb the
-    # conformer to ensure it needs minimization.
+    # Load in a paracetamol molecule and generate a conformer for it.
     molecule: Molecule = Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")
     molecule.generate_conformers(n_conformers=1)
     molecule.to_file("initial.xyz", "XYZ")
@@ -22,7 +21,8 @@ def main():
         ForceField("openff_unconstrained-1.0.0.offxml"), molecule.to_topology()
     )
 
-    # Specify the parameters that we want to take the derivative with respect to.
+    # Specify the parameters that we want to differentiate respect to, as well as a
+    # tensor that the computed gradients will be attached to.
     parameter_ids = [
         (handler_type, potential_key, attribute)
         for handler_type, handler in openff_system.handlers.items()
@@ -31,8 +31,6 @@ def main():
         for potential_key, potential in handler.potentials.items()
         for attribute in potential.parameters
     ]
-
-    # Specify the tensor that the computed gradients will be attached to.
     parameter_delta = torch.zeros(len(parameter_ids), requires_grad=True)
 
     # Compute the energies and backpropagate to get gradient of the energy with respect

--- a/examples/parameter-gradients.py
+++ b/examples/parameter-gradients.py
@@ -1,0 +1,54 @@
+import torch
+from openff.system.components.system import System
+from openff.toolkit.topology import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from simtk import unit
+
+from smirnoffee.potentials.potentials import evaluate_system_energy
+
+
+def main():
+
+    # Load in a paracetamol molecules, generate a conformer for it, and perturb the
+    # conformer to ensure it needs minimization.
+    molecule: Molecule = Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")
+    molecule.generate_conformers(n_conformers=1)
+    molecule.to_file("initial.xyz", "XYZ")
+
+    conformer = torch.tensor(molecule.conformers[0].value_in_unit(unit.angstrom)) * 1.10
+
+    # Parameterize the molecule
+    openff_system = System.from_smirnoff(
+        ForceField("openff_unconstrained-1.0.0.offxml"), molecule.to_topology()
+    )
+
+    # Specify the parameters that we want to take the derivative with respect to.
+    parameter_ids = [
+        (handler_type, potential_key, attribute)
+        for handler_type, handler in openff_system.handlers.items()
+        # Computing the gradients w.r.t. nonbonded handlers is not yet supported.
+        if handler_type not in ["Electrostatics", "vdW", "ToolkitAM1BCC"]
+        for potential_key, potential in handler.potentials.items()
+        for attribute in potential.parameters
+    ]
+
+    # Specify the tensor that the computed gradients will be attached to.
+    parameter_delta = torch.zeros(len(parameter_ids), requires_grad=True)
+
+    # Compute the energies and backpropagate to get gradient of the energy with respect
+    # to the parameters specified above.
+    energy = evaluate_system_energy(
+        openff_system,
+        conformer,
+        parameter_delta=parameter_delta,
+        parameter_delta_ids=parameter_ids
+    )
+    energy.backward()
+
+    # Print the gradients.
+    for parameter_id, gradient in zip(parameter_ids, parameter_delta.grad.numpy()):
+        print(f"{parameter_id} - {gradient}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR adds two simple examples for using this framework:

* `conformer-minimization.py` which shows how a paracetamol conformer can be minimized
* `parameter-gradients.py` which shows how to compute the gradient of a systems energy with respect to force field parameters.

## Status
- [X] Ready to go