### PR TITLE
Fix non-bonded scale factors and patch acos singularity

### DIFF
--- a/smirnoffee/smirnoff.py
+++ b/smirnoffee/smirnoff.py
@@ -253,29 +253,36 @@ def _vectorize_nonbonded_scales(
     }
 
     interaction_pairs = {
-        **{
-            tuple(sorted((bond.atom1_index, bond.atom2_index))): "scale_12"
-            for bond in molecule.bonds
-        },
-        **{
-            tuple(
-                sorted((angle[0].molecule_atom_index, angle[2].molecule_atom_index))
-            ): "scale_13"
-            for angle in molecule.angles
-        },
-        **{
-            tuple(
-                sorted((proper[0].molecule_atom_index, proper[3].molecule_atom_index))
-            ): "scale_14"
-            for proper in molecule.propers
-        },
+        tuple(sorted((bond.atom1_index, bond.atom2_index))): "scale_12"
+        for bond in molecule.bonds
+    }
+
+    pairs_13 = {
+        tuple(
+            sorted((angle[0].molecule_atom_index, angle[2].molecule_atom_index))
+        ): "scale_13"
+        for angle in molecule.angles
     }
     interaction_pairs.update(
-        {
-            tuple(sorted(pair)): "scale_1n"
-            for pair in itertools.combinations(range(molecule.n_atoms), 2)
-            if tuple(sorted(pair)) not in interaction_pairs
-        }
+        {key: value for key, value in pairs_13.items() if key not in interaction_pairs}
+    )
+
+    pairs_14 = {
+        tuple(
+            sorted((proper[0].molecule_atom_index, proper[3].molecule_atom_index))
+        ): "scale_14"
+        for proper in molecule.propers
+    }
+    interaction_pairs.update(
+        {key: value for key, value in pairs_14.items() if key not in interaction_pairs}
+    )
+
+    pairs_1n = {
+        tuple(sorted(pair)): "scale_1n"
+        for pair in itertools.combinations(range(molecule.n_atoms), 2)
+    }
+    interaction_pairs.update(
+        {key: value for key, value in pairs_1n.items() if key not in interaction_pairs}
     )
 
     if len(interaction_pairs) == 0 or all(

--- a/smirnoffee/tests/potentials/test_potentials.py
+++ b/smirnoffee/tests/potentials/test_potentials.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 from openff.system.components.system import System
 from openff.system.models import PotentialKey
-from openff.toolkit.topology import Molecule
 from simtk import unit
 
 from smirnoffee.exceptions import MissingArgumentsError

--- a/smirnoffee/tests/potentials/test_potentials.py
+++ b/smirnoffee/tests/potentials/test_potentials.py
@@ -134,10 +134,7 @@ def test_evaluate_handler_energy(request, handler, molecule_name, default_force_
     )
     expected_energy = evaluate_openmm_energy(molecule, conformer.numpy(), force_field)
 
-    if handler == "ImproperTorsions":
-        assert numpy.isclose(expected_energy, openff_energy.numpy(), atol=1e-6)
-    else:
-        assert numpy.isclose(expected_energy, openff_energy.numpy())
+    assert numpy.isclose(expected_energy, openff_energy.numpy())
 
 
 @pytest.mark.parametrize(
@@ -189,11 +186,7 @@ def test_evaluate_handler_energy_delta(
     openff_energy = evaluate_handler_energy(
         openff_system.handlers[handler], molecule, conformer, delta_values, delta_ids
     )
-
-    if handler == "ImproperTorsions":
-        assert numpy.isclose(expected_energy, openff_energy.detach().numpy(), atol=1e-4)
-    else:
-        assert numpy.isclose(expected_energy, openff_energy.numpy())
+    assert numpy.isclose(expected_energy, openff_energy.detach().numpy())
 
     openff_energy.backward()
     assert not numpy.allclose(delta_values.grad, torch.zeros_like(delta_values.grad))

--- a/smirnoffee/tests/potentials/test_potentials.py
+++ b/smirnoffee/tests/potentials/test_potentials.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from openff.system.components.system import System
 from openff.system.models import PotentialKey
+from openff.toolkit.topology import Molecule
 from simtk import unit
 
 from smirnoffee.exceptions import MissingArgumentsError
@@ -134,7 +135,10 @@ def test_evaluate_handler_energy(request, handler, molecule_name, default_force_
     )
     expected_energy = evaluate_openmm_energy(molecule, conformer.numpy(), force_field)
 
-    assert numpy.isclose(expected_energy, openff_energy.numpy())
+    if handler == "ImproperTorsions":
+        assert numpy.isclose(expected_energy, openff_energy.numpy(), atol=1e-6)
+    else:
+        assert numpy.isclose(expected_energy, openff_energy.numpy())
 
 
 @pytest.mark.parametrize(
@@ -187,7 +191,10 @@ def test_evaluate_handler_energy_delta(
         openff_system.handlers[handler], molecule, conformer, delta_values, delta_ids
     )
 
-    assert numpy.isclose(expected_energy, openff_energy.detach().numpy())
+    if handler == "ImproperTorsions":
+        assert numpy.isclose(expected_energy, openff_energy.detach().numpy(), atol=1e-4)
+    else:
+        assert numpy.isclose(expected_energy, openff_energy.numpy())
 
     openff_energy.backward()
     assert not numpy.allclose(delta_values.grad, torch.zeros_like(delta_values.grad))


### PR DESCRIPTION
## Description

This PR fixes a bug whereby the 1-4 scaling factor could be applied to the 1-3 and 1-2 position in rings. It also temporarily patches the `nan` singularity when computing angles using `acos` close to 1.0 or -1.0.

## Status
- [X] Ready to go