### PR TITLE
Migrate to first full `openff-interchange` release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.9]
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -29,7 +29,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/meta.yaml
+        environment-file: devtools/conda-envs/test-env.yaml
 
         channels: conda-forge,defaults
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -1,7 +1,6 @@
 name: test
 
 channels:
-  - openeye
   - conda-forge
   - defaults
 
@@ -11,13 +10,11 @@ dependencies:
   - python
 
   - openff-toolkit-base >=0.9.2
+  - openff-units
+  - openff-interchange ==0.1.0  # hard pin until API stabilizes
+
   - pytorch-cpu
   - pydantic
-
-  # --------- openff-system ---------
-  - openff-utilities
-  - pint
-  # --------- openff-system ---------
 
     # Optional dependencies
   - rdkit
@@ -27,8 +24,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-
-  - pip:
-
-      - git+git://github.com/openforcefield/openff-units.git
-      - git+git://github.com/openforcefield/openff-system.git

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   - openff-toolkit-base >=0.9.2
   - openff-units
-  - openff-interchange ==0.1.0  # hard pin until API stabilizes
+  - openff-interchange ==0.1.0  # Hard pin until API stabilizes
 
   - pytorch-cpu
   - pydantic

--- a/examples/conformer-minimization.py
+++ b/examples/conformer-minimization.py
@@ -1,5 +1,5 @@
 import torch
-from openff.system.components.system import System
+from openff.interchange.components.interchange import Interchange
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from simtk import unit
@@ -20,7 +20,7 @@ def main():
     conformer.requires_grad = True
 
     # Parameterize the molecule
-    openff_system = System.from_smirnoff(
+    openff_system = Interchange.from_smirnoff(
         ForceField("openff_unconstrained-1.0.0.offxml"), molecule.to_topology()
     )
 

--- a/examples/parameter-gradients.py
+++ b/examples/parameter-gradients.py
@@ -1,5 +1,5 @@
 import torch
-from openff.system.components.system import System
+from openff.interchange.components.interchange import Interchange
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from simtk import unit
@@ -17,7 +17,7 @@ def main():
     conformer = torch.tensor(molecule.conformers[0].value_in_unit(unit.angstrom)) * 1.10
 
     # Parameterize the molecule
-    openff_system = System.from_smirnoff(
+    openff_system = Interchange.from_smirnoff(
         ForceField("openff_unconstrained-1.0.0.offxml"), molecule.to_topology()
     )
 

--- a/smirnoffee/potentials/potentials.py
+++ b/smirnoffee/potentials/potentials.py
@@ -1,9 +1,9 @@
 from typing import Dict, List, Optional, Tuple
 
 import torch
-from openff.system.components.smirnoff import SMIRNOFFPotentialHandler
-from openff.system.components.system import System
-from openff.system.models import PotentialKey
+from openff.interchange.components.interchange import Interchange
+from openff.interchange.components.smirnoff import SMIRNOFFPotentialHandler
+from openff.interchange.models import PotentialKey
 from openff.toolkit.topology import Molecule
 
 from smirnoffee.exceptions import MissingArgumentsError
@@ -183,7 +183,7 @@ def evaluate_vectorized_handler_energy(
 
 
 def evaluate_system_energy(
-    system: System,
+    system: Interchange,
     conformer: torch.Tensor,
     parameter_delta: Optional[torch.Tensor] = None,
     parameter_delta_ids: Optional[List[Tuple[str, PotentialKey, str]]] = None,

--- a/smirnoffee/smirnoff.py
+++ b/smirnoffee/smirnoff.py
@@ -4,18 +4,18 @@ from typing import Dict, List, Tuple, Union
 
 import numpy
 import torch
-from openff.system.components.potentials import Potential, PotentialHandler
-from openff.system.components.smirnoff import (
-    ElectrostaticsMetaHandler,
+from openff.interchange.components.interchange import Interchange
+from openff.interchange.components.potentials import Potential, PotentialHandler
+from openff.interchange.components.smirnoff import (
     SMIRNOFFAngleHandler,
     SMIRNOFFBondHandler,
+    SMIRNOFFElectrostaticsHandler,
     SMIRNOFFImproperTorsionHandler,
     SMIRNOFFPotentialHandler,
     SMIRNOFFProperTorsionHandler,
     SMIRNOFFvdWHandler,
 )
-from openff.system.components.system import System
-from openff.system.models import PotentialKey, TopologyKey
+from openff.interchange.models import PotentialKey, TopologyKey
 from openff.toolkit.topology import Molecule
 from openff.units import unit
 
@@ -236,7 +236,8 @@ def vectorize_improper_handler(
 
 
 def _vectorize_nonbonded_scales(
-    handler: Union[SMIRNOFFvdWHandler, ElectrostaticsMetaHandler], molecule: Molecule
+    handler: Union[SMIRNOFFvdWHandler, SMIRNOFFElectrostaticsHandler],
+    molecule: Molecule,
 ) -> Tuple[Tuple[Tuple[int, int], ...], Tuple[float, ...], Tuple[str, ...]]:
     """Vectorizes the 1-n scale factors associated with a set of nonbonded interaction
     pairs.
@@ -383,7 +384,7 @@ def vectorize_vdw_handler(
 
 @handler_vectorizer("Electrostatics")
 def vectorize_electrostatics_handler(
-    handler: ElectrostaticsMetaHandler, molecule: Molecule
+    handler: SMIRNOFFElectrostaticsHandler, molecule: Molecule
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
@@ -476,7 +477,7 @@ def vectorize_handler(
     return vectorizer(handler)
 
 
-def vectorize_system(system: System) -> Dict[Tuple[str, str], VectorizedHandler]:
+def vectorize_system(system: Interchange) -> Dict[Tuple[str, str], VectorizedHandler]:
     """Maps a SMIRNOFF parameterized system object into a collection of tensor
     representations.
 

--- a/smirnoffee/tests/conftest.py
+++ b/smirnoffee/tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
-from openff.system.components.system import System
-from openff.system.stubs import ForceField
+from openff.interchange.components.interchange import Interchange
 from openff.toolkit.topology import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
 
 @pytest.fixture(scope="module")
@@ -18,10 +18,11 @@ def default_force_field() -> ForceField:
 
 @pytest.fixture(scope="module")
 def ethanol() -> Molecule:
-    """Returns an OpenFF ethanol molecule."""
+    """Returns an OpenFF ethanol molecule with a fixed atom order."""
 
-    molecule: Molecule = Molecule.from_smiles("CCO")
-    return molecule.canonical_order_atoms()
+    return Molecule.from_mapped_smiles(
+        "[H:5][C:2]([H:6])([H:7])[C:3]([H:8])([H:9])[O:1][H:4]"
+    )
 
 
 @pytest.fixture(scope="module")
@@ -38,15 +39,15 @@ def ethanol_conformer(ethanol) -> torch.Tensor:
 
 
 @pytest.fixture(scope="module")
-def ethanol_system(ethanol, default_force_field) -> System:
+def ethanol_system(ethanol, default_force_field) -> Interchange:
     """Returns a parametermized system of ethanol."""
 
-    return System.from_smirnoff(default_force_field, ethanol.to_topology())
+    return Interchange.from_smirnoff(default_force_field, ethanol.to_topology())
 
 
 @pytest.fixture(scope="module")
 def formaldehyde() -> Molecule:
-    """Returns an OpenFF formaldehyde molecule."""
+    """Returns an OpenFF formaldehyde molecule with a fixed atom order.."""
 
     molecule: Molecule = Molecule.from_smiles("C=O")
     return molecule.canonical_order_atoms()
@@ -66,7 +67,7 @@ def formaldehyde_conformer(formaldehyde) -> torch.Tensor:
 
 
 @pytest.fixture(scope="module")
-def formaldehyde_system(formaldehyde, default_force_field) -> System:
+def formaldehyde_system(formaldehyde, default_force_field) -> Interchange:
     """Returns a parametermized system of formaldehyde."""
 
-    return System.from_smirnoff(default_force_field, formaldehyde.to_topology())
+    return Interchange.from_smirnoff(default_force_field, formaldehyde.to_topology())

--- a/smirnoffee/tests/conftest.py
+++ b/smirnoffee/tests/conftest.py
@@ -49,8 +49,7 @@ def ethanol_system(ethanol, default_force_field) -> Interchange:
 def formaldehyde() -> Molecule:
     """Returns an OpenFF formaldehyde molecule with a fixed atom order.."""
 
-    molecule: Molecule = Molecule.from_smiles("C=O")
-    return molecule.canonical_order_atoms()
+    return Molecule.from_mapped_smiles("[H:3][C:1](=[O:2])[H:4]")
 
 
 @pytest.fixture(scope="module")

--- a/smirnoffee/tests/potentials/test_potentials.py
+++ b/smirnoffee/tests/potentials/test_potentials.py
@@ -3,8 +3,8 @@ import copy
 import numpy
 import pytest
 import torch
-from openff.system.components.system import System
-from openff.system.models import PotentialKey
+from openff.interchange.components.interchange import Interchange
+from openff.interchange.models import PotentialKey
 from simtk import unit
 
 from smirnoffee.exceptions import MissingArgumentsError
@@ -127,7 +127,7 @@ def test_evaluate_handler_energy(request, handler, molecule_name, default_force_
 
     force_field = reduce_and_perturb_force_field(default_force_field, handler)
 
-    openff_system = System.from_smirnoff(force_field, molecule.to_topology())
+    openff_system = Interchange.from_smirnoff(force_field, molecule.to_topology())
 
     openff_energy = evaluate_handler_energy(
         openff_system.handlers[handler], molecule, conformer
@@ -156,7 +156,7 @@ def test_evaluate_handler_energy_delta(
     conformer = request.getfixturevalue(f"{molecule_name}_conformer")
 
     force_field = reduce_and_perturb_force_field(default_force_field, handler)
-    openff_system = System.from_smirnoff(force_field, molecule.to_topology())
+    openff_system = Interchange.from_smirnoff(force_field, molecule.to_topology())
 
     deltas = {
         (key, parameter): _get_parameter_value(potential, handler, parameter) * 0.01

--- a/smirnoffee/tests/utilities.py
+++ b/smirnoffee/tests/utilities.py
@@ -2,7 +2,7 @@ import copy
 from typing import Dict, Tuple
 
 import numpy
-from openff.system.models import PotentialKey
+from openff.interchange.models import PotentialKey
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from simtk import unit


### PR DESCRIPTION
## Description

This PR migrates to the first 'full' release of the `openff-interchange` package (previously `openff-system`) that is now available on C-F. 

This mostly includes updating the import statement, but also required making the vectorisation tests more resilient to changes in slot ordering.

## Status
- [X] Ready to go